### PR TITLE
nonretryable err

### DIFF
--- a/helloworld/helloworld.go
+++ b/helloworld/helloworld.go
@@ -2,19 +2,60 @@ package helloworld
 
 import (
 	"context"
+	"reflect"
 	"time"
 
 	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 
 	// TODO(cretz): Remove when tagged
 	_ "go.temporal.io/sdk/contrib/tools/workflowcheck/determinism"
 )
 
+type ErrorCode string
+
+const (
+	ErrorCodeFoo ErrorCode = "foo"
+)
+
+type NonRetryableError struct {
+	Err  string
+	Code *ErrorCode
+}
+
+func (e *NonRetryableError) Error() string {
+	return e.Err
+}
+
+func NewNonRetryableError(err string) error {
+	nonRetryErr := NonRetryableError{
+		Err: err,
+	}
+
+	return &nonRetryErr
+}
+
+func NewNonRetryableErrorWithCode(err string, code ErrorCode) error {
+	nonRetryErr := NonRetryableError{
+		Err:  err,
+		Code: &code,
+	}
+
+	return &nonRetryErr
+}
+
+var (
+	nonRetryableErrorType = reflect.TypeOf(NewNonRetryableError("")).Elem().Name()
+)
+
 // Workflow is a Hello World workflow definition.
 func Workflow(ctx workflow.Context, name string) (string, error) {
 	ao := workflow.ActivityOptions{
 		StartToCloseTimeout: 10 * time.Second,
+		RetryPolicy: &temporal.RetryPolicy{
+			NonRetryableErrorTypes: []string{nonRetryableErrorType},
+		},
 	}
 	ctx = workflow.WithActivityOptions(ctx, ao)
 
@@ -36,5 +77,7 @@ func Workflow(ctx workflow.Context, name string) (string, error) {
 func Activity(ctx context.Context, name string) (string, error) {
 	logger := activity.GetLogger(ctx)
 	logger.Info("Activity", "name", name)
-	return "Hello " + name + "!", nil
+
+	// return "Hello " + name + "!", nil
+	return "", NewNonRetryableErrorWithCode("foo", ErrorCodeFoo)
 }

--- a/helloworld/starter/main.go
+++ b/helloworld/starter/main.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log"
 
 	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
 
 	"github.com/temporalio/samples-go/helloworld"
 )
@@ -33,7 +35,22 @@ func main() {
 	var result string
 	err = we.Get(context.Background(), &result)
 	if err != nil {
-		log.Fatalln("Unable get workflow result", err)
+		log.Println("Unable get workflow result", err)
+
+		var nonRetryErr *helloworld.NonRetryableError
+		if errors.As(err, &nonRetryErr) {
+			log.Println("NonRetryableError", nonRetryErr.Err, nonRetryErr.Code)
+		} else {
+			log.Println("Cannot convert to NonRetryableError")
+		}
+
+		var appErr *temporal.ApplicationError
+		if errors.As(err, &appErr) {
+			log.Println("ApplicationError", appErr)
+			log.Println("HasDetails", appErr.HasDetails())
+		} else {
+			log.Println("Cannot convert to ApplicationError")
+		}
 	}
 	log.Println("Workflow result:", result)
 }


### PR DESCRIPTION
Shows how we currently create a NonRetryableError and set a code on it and try to deserialize that type with its code from a temporal workflow.

output:
```
2022/09/15 16:27:58 Cannot convert to NonRetryableError
2022/09/15 16:27:58 ApplicationError foo (type: NonRetryableError, retryable: true)
2022/09/15 16:27:58 HasDetails false
2022/09/15 16:27:58 Workflow result:
```